### PR TITLE
Bugfix for ASM+LTM policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Please document all changes here.
 Follow rules from [Keep a Changelog](https://keepachangelog.com/en/0.3.0/)
 
+## [Unreleased]
+### Changed
+- Found and fixed bug introduced in last version - variable from previous iteration was used if not explicitly reset.
+
 ## [2.0.3] - 2020-09-30
 - Added option to define partitions for ASM policies
 - Fixed bug with re-creating ASM policy instead of deactivating

--- a/tasks/ltm_vs_deploy.yml
+++ b/tasks/ltm_vs_deploy.yml
@@ -1,4 +1,8 @@
 ---
+- name: Reset asm_ltm_policy variable
+  set_fact:
+    asm_ltm_policy: ""
+
 - block:
     - name: Set name of LTM policy
       set_fact:


### PR DESCRIPTION
Bug was trying to assign asm policy from previous iteration to another VS, if the variable was not overwritten by another policy name.